### PR TITLE
v3.0.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,3 @@
 Makefile          export-ignore
 phpunit.xml       export-ignore
 composer.lock     export-ignore
-

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
-build/*          export-ignore
-docs/*           export-ignore
-tests/*          export-ignore
-.editorconfig    export-ignore
-.gitattributes   export-ignore
-.gitignore       export-ignore
-.travis          export-ignore
-Makefile         export-ignore
-phpunit.xml      export-ignore
+/build            export-ignore
+/docs             export-ignore
+/tests            export-ignore
+/examples         export-ignore
+.editorconfig     export-ignore
+.gitattributes    export-ignore
+.gitignore        export-ignore
+.travis.yml       export-ignore
+Makefile          export-ignore
+phpunit.xml       export-ignore
+composer.lock     export-ignore
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,30 @@ sudo: false
 language: php
 
 php:
-  - 7.0
-  - 7.0snapshot
-  - 7.1
-  - 7.1snapshot
-  - master
+    - 7.0
+    - 7.0snapshot
+    - 7.1
+    - 7.1snapshot
 
 cache:
-  directories:
-    - $HOME/.composer/cache/files
+    directories:
+        - $HOME/.composer/cache/files
 
 env:
-  matrix:
-    - DEPENDENCIES="high"
-    - DEPENDENCIES="low"
+    matrix:
+        - DEPENDENCIES="high"
+        - DEPENDENCIES="low"
 
 before_install:
-  - composer self-update
-  - composer clear-cache
+    - composer self-update
+    - composer clear-cache
 
 install:
-  - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable; fi
-  - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable --prefer-lowest; fi
+    - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable; fi
+    - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable --prefer-lowest; fi
 
-script: make test
+script:
+    - make test
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -8,16 +8,20 @@
 
 _* Presentation card - [view sample code](#creating-a-simple-presentation-card)_
 
-__GImage__ is a simple extended library based on [PHP Image Processing and GD](http://php.net/manual/en/book.image.php) for processing images without stress. For example:
+__GImage__ is a simple extended library based on [PHP Image Processing and GD](http://php.net/manual/en/book.image.php) for processing images without stress.
+
+With GImage you can:
+
 - Load a image from local path or URL.
-- Create figures like a rectangles or ellipses with opacity.
-- Rotate and crop (proportionally).
-- Resize and scale proportionally.
+- Create shapes such as rectangles or ellipses with opacity.
+- Resize or scale images proportionally.
+- Crop images proportionally.
+- Rotate images, shapes or texts.
 - Embed text with custom TTF fonts.
-- Compose a pool of images with Canvas.
-- Swap image formats like JPG, PNG and GIF.
-- Save file or output on browser.
-- Save several copies of an image.
+- Compose a pool of images with `Canvas`.
+- Swap image formats such as JPEG, PNG and GIF.
+- Save images in local or output on the browser.
+- Save several copies of the same image.
 
 ## Requirements
 GImage requires **[PHP 7.x](http://php.net/manual/en/migration70.new-features.php)** and latest [GD Extension](http://php.net/manual/en/book.image.php).
@@ -30,8 +34,6 @@ composer require joseluisq/gimage
 
 ## Usage
 
-For more examples check out the [./examples](./examples) dir.
-
 #### Image
 
 Working with an external JPG image and output it on browser as PNG format:
@@ -43,11 +45,13 @@ use GImage\Image;
 
 $avatar = new Image();
 $avatar
-	// Loading an image (200x200) from an URL (or local path)
-	->load('https://assets-cdn.github.com/images/modules/logos_page/Octocat.png');
+	// Loading a JPEG image (200x200) from an URL (or local path too)
+	->load('http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=200.jpg');
 	// Scaling to 50% (100x100)
 	->scale(50)
-	// Changing to PNG format
+	// Set 50% of opacity
+	->setOpacity(0.5)
+	// Changing the format to PNG
 	->toPNG()
 	// Preserving the image before saving or outputting
 	->preserve()
@@ -206,6 +210,8 @@ $canvas
 	->draw()
 	->save('./card.png');
 ```
+
+For more examples check out the [./examples](./examples) dir.
 
 ## Changelog
 Check out the [CHANGELOG.md](./CHANGELOG.md) file.

--- a/examples/ellipse.php
+++ b/examples/ellipse.php
@@ -26,6 +26,6 @@ $figure = new Figure(300, 200);
 $figure
     ->isEllipse()
     ->setBackgroundColor(255, 0, 0)
-    ->setOpacity(35)
+    ->setOpacity(0.3)
     ->create()
     ->save(__DIR__ . '/ellipse.png');

--- a/examples/rectangle.php
+++ b/examples/rectangle.php
@@ -29,6 +29,6 @@ $figure = new Figure(400, 250);
 $figure
     ->isRectangle()
     ->setBackgroundColor(0, 0, 255)
-    ->setOpacity(50)
+    ->setOpacity(0.5)
     ->create()
     ->save(__DIR__ . '/reactangle.png');

--- a/examples/rotate.php
+++ b/examples/rotate.php
@@ -24,6 +24,9 @@ require __DIR__ . '/../tests/bootstrap.php';
 // Rotate an image to 90º
 $image = new Image();
 $image
-    ->load('http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=100.jpg')
+    ->load('http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=200.jpg')
+    ->scale(0.5)
     ->rotate(90)
-    ->save(__DIR__ . '/rotate.jpg');
+    ->toPNG()
+    ->setOpacity(0.7)
+    ->save(__DIR__ . '/rotate.png');

--- a/examples/text.php
+++ b/examples/text.php
@@ -36,6 +36,7 @@ $text
     ->setAlign('center')
     ->setValign('center')
     ->setSize(22)
+    ->setOpacity(0.3)
     ->setColor(255, 255, 255)
     ->setFontface(BASE_PATH . '/fonts/Lato-Bol.ttf');
 

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -12,6 +12,7 @@ namespace GImage;
 
 use GImage\Image;
 use GImage\Text;
+use GImage\Utils;
 
 /**
  * A Canvas represents a rectangular image area on which one can draw images.
@@ -129,13 +130,14 @@ class Canvas extends Image
     private function drawText(Text $text, $canvas)
     {
         list($red, $green, $blue) = $text->getColor();
+        $opacity = Utils::fixPNGOpacity($text->getOpacity());
 
         $color = imagecolorallocatealpha(
             $canvas,
             $red,
             $green,
             $blue,
-            $text->getOpacity()
+            $opacity
         );
 
         $size = $text->getSize();

--- a/src/Figure.php
+++ b/src/Figure.php
@@ -11,6 +11,7 @@
 namespace GImage;
 
 use GImage\Image;
+use GImage\Utils;
 
 /**
  * Class to embed simple graphic into the Canvas.
@@ -129,20 +130,18 @@ class Figure extends Image
         $figure = imagecreatetruecolor($this->width, $this->height);
         imagesavealpha($figure, true);
 
+        $opacity = Utils::fixPNGOpacity($this->opacity);
+
         $color = imagecolorallocatealpha(
             $figure,
             $this->red,
             $this->green,
             $this->blue,
-            $this->opacity
+            $opacity
         );
 
         $alpha = imagecolorallocatealpha($figure, 255, 255, 255, 127);
-
         imagefill($figure, 0, 0, $alpha);
-        imagefill($figure, $this->width - 1, 0, $alpha);
-        imagefill($figure, 0, $this->height - 1, $alpha);
-        imagefill($figure, $this->width - 1, $this->height - 1, $alpha);
 
         if ($this->figureType == 'rectangle') {
             imagefilledrectangle(

--- a/src/Image.php
+++ b/src/Image.php
@@ -712,13 +712,18 @@ class Image
     /**
     * Scales the image.
     * @access public
-    * @param int $scale
+    * @param int|double $scale
     * @return \GImage\Image
     */
-    public function scale($scale)
+    public function scale($scale = 1)
     {
-        $width = $this->width * (int) $scale / 100;
-        $height = $this->height * (int) $scale / 100;
+        if ($scale > 1) {
+            $scale = 1;
+        }
+
+        $width = (int) $this->width * $scale;
+        $height = (int) $this->height * $scale;
+
         $this->resize($width, $height);
         return $this;
     }
@@ -732,7 +737,10 @@ class Image
     */
     public function rotate($angle = 0)
     {
-        $this->resource = imagerotate($this->resource, $angle, 0);
+        if ($this->resource) {
+            $this->resource = imagerotate($this->resource, $angle, 0);
+        }
+
         return $this;
     }
 
@@ -803,7 +811,7 @@ class Image
     {
         $image = $this->resource;
 
-        if ($image) {
+        if ($image && $width > 0 && $height > 0) {
             $simage = imagecreatetruecolor($width, $height);
 
             if ($this->isPNG()) {

--- a/src/Image.php
+++ b/src/Image.php
@@ -33,7 +33,7 @@ use GImage\Utils;
  * @property string $extension Default 'jpg'
  * @property resource $resource
  * @property int $quality
- * @property int $opacity
+ * @property int $opacity From 0 to 1
  * @property string $from Default 'local'
  * @property bool $preserve Default FALSE
  * @property string $mimetype Default 'image/jpeg'
@@ -54,7 +54,7 @@ class Image
     protected $extension = 'jpg';
     protected $resource;
     protected $quality = 100;
-    protected $opacity = 0;
+    protected $opacity = 1;
     protected $from = 'local';
     protected $preserve = false;
     protected $mimetype = 'image/jpeg';
@@ -880,8 +880,15 @@ class Image
                 $quality = 0;
             }
 
+            $opacity = Utils::fixPNGOpacity($this->opacity);
+
             imagealphablending($image, false);
             imagesavealpha($image, true);
+
+            if ($opacity >= 0 && $opacity < 127) {
+                imagefilter($image, IMG_FILTER_COLORIZE, 0, 0, 0, $opacity);
+            }
+
             imagepng($image, $filename, $quality);
         }
 

--- a/src/Text.php
+++ b/src/Text.php
@@ -116,12 +116,12 @@ class Text
     * Sets text's opacity.
     *
     * @access public
-    * @param int $opacity Opacity value from 0 to 127
+    * @param int $opacity Opacity value from 0 to 1
     * @return void
     */
     public function setOpacity($opacity)
     {
-        $this->opacity = $opacity > 127 ? 127 : $opacity;
+        $this->opacity = $opacity;
 
         return $this;
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -152,4 +152,19 @@ class Utils
         return $resource && (bin2hex($resource[0]) == '89' && $resource[1] == 'P'
                 && $resource[2] == 'N' && $resource[3] == 'G');
     }
+
+    /**
+    * Fix the opacity value (0 to 1) for PNG alpha value.
+    *
+    * @access public
+    * @param int|double $opacity
+    * @return int|double
+    */
+    public static function fixPNGOpacity($opacity = 1)
+    {
+        $opacity = $opacity > 1 ? 1 : $opacity;
+        $opacity = $opacity < 0 ? 0 : $opacity;
+        $opacity = 127 - (127 * $opacity);
+        return $opacity;
+    }
 }

--- a/tests/GImageTest.php
+++ b/tests/GImageTest.php
@@ -99,7 +99,7 @@ class GImageTest extends TestCase
     public function testScale(Image $img)
     {
         // Scaling to 50% (100x100)
-        $img->scale(50);
+        $img->scale(0.5);
 
         return $img;
     }


### PR DESCRIPTION
### Add
- `Utils::fixPNGOpacity()` function that fix the opacity value between `0` and `1` for PNG alpha value.

### Changed
- `setOpacity` (`Figure`, `Image` and `Text` classes) method now support values from `0` to `1` only.

```php
<?php
// Set opacity to 50%
$figure->setOpacity(0.5)
```

### Fixed
- `setOpacity` now works if it loads some JPEG image and then saves it as PNG.
- Fixed the opacity tests.
- Fixed the examples for opacity support.

### Removed
- Some unnecessary functions for figure class.

### Deprecated
- `setOpacity` doesn't support values from 0 to 100.
