### PR TITLE
Utils::isJPGResource and Utils::isPNGResource method require a string parameter

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -101,7 +101,7 @@ class Image
             return $this;
         }
 
-        if ($this->isImageString($src)) {
+        if ($this->isImageStringByString($src)) {
             $this->loadImageFromString($src);
         } elseif (filter_var($src, FILTER_VALIDATE_URL)) {
             $this->loadImageFromURL($src);
@@ -191,7 +191,7 @@ class Image
      * @param  string $imagestring Image string.
      * @return bool
      */
-    private function isImageString($imagestring){
+    private function isImageStringByString($imagestring){
         return Utils::isJPGResource($imagestring) || Utils::isPNGResource($imagestring);
     }
 
@@ -556,14 +556,14 @@ class Image
     }
 
     /**
-     * Checks if image was loaded from resource.
+     * Checks if image was loaded from image string.
      *
      * @access public
      * @return bool
      */
-    public function isResource()
+    public function isImageString()
     {
-        return ($this->from == 'resource');
+        return ($this->from == 'imagestring');
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -88,11 +88,11 @@ class Image
     }
 
     /**
-     * Loads an image from a local path, external url or image resource.
+     * Loads an image from a local path, external url or image string.
      *
      * @package GImage
      * @access public
-     * @param string|resource $src Local path, external url or image resource.
+     * @param string $src Local path, external url or image string.
      * @return \GImage\Image
      */
     public function load($src)
@@ -101,8 +101,8 @@ class Image
             return $this;
         }
 
-        if (is_resource($src)) {
-            $this->loadImageFromResource($src);
+        if ($this->isImageString($src)) {
+            $this->loadImageFromString($src);
         } elseif (filter_var($src, FILTER_VALIDATE_URL)) {
             $this->loadImageFromURL($src);
         } elseif (is_file($src)) {
@@ -163,33 +163,36 @@ class Image
     }
 
     /**
-     * Load an image from resource.
+     * Load an image from image string.
      *
-     * @param  resource $resource Image resource
+     * @param  string $imagestring Image string
      * @return void
      */
-    private function loadImageFromResource($resource)
+    private function loadImageFromString($imagestring)
     {
-        if (!is_resource($resource)) {
-            return;
-        }
-
-        if (Utils::isJPGResource($resource)) {
-            $this->filename = $url;
+        if (Utils::isJPGResource($imagestring)) {
             $this->extension = 'jpg';
             $this->type = IMAGETYPE_JPEG;
         }
 
-        if (Utils::isPNGResource($resource)) {
-            $this->filename = $url;
+        if (Utils::isPNGResource($imagestring)) {
             $this->extension = 'png';
             $this->type = IMAGETYPE_PNG;
         }
 
-        $this->from = 'resource';
-        $this->resource = $resource;
-        $this->width = $this->boxWidth = imagesx($resource);
-        $this->height = $this->boxHeight = imagesy($resource);
+        $this->from = 'imagestring';
+        $this->resource = imagecreatefromstring($imagestring);
+        $this->width = $this->boxWidth = imagesx($this->resource);
+        $this->height = $this->boxHeight = imagesy($this->resource);
+    }
+
+    /**
+     * Checks if string is Image string.
+     * @param  string $imagestring Image string.
+     * @return bool
+     */
+    private function isImageString($imagestring){
+        return Utils::isJPGResource($imagestring) || Utils::isPNGResource($imagestring);
     }
 
     /**

--- a/tests/GImageTest.php
+++ b/tests/GImageTest.php
@@ -96,9 +96,9 @@ class GImageTest extends TestCase
     /**
     * @depends testGetResource
     */
-    public function testIsResource(Image $img)
+    public function testIsImageString(Image $img)
     {
-        $this->assertFalse($img->isResource());
+        $this->assertFalse($img->isImageString());
     }
 
     /**
@@ -261,18 +261,18 @@ class GImageTest extends TestCase
     /**
     * @depends testCanvasSave
     */
-    public function testLoadResource(Canvas $canvas)
+    public function testLoadImageString(Canvas $canvas)
     {
-        $rectangle = imagecreatefromjpeg(GIMAGE_PATH_TMP . DS . 'test3.jpg');
-        $this->assertNotNull($rectangle);
+        $imagestring = file_get_contents(GIMAGE_PATH_TMP . DS . 'test3.jpg');
+        $this->assertNotNull($imagestring);
 
         $img = new Image();
         $img
-            ->load($rectangle)
+            ->load($imagestring)
             ->scale(0.50)
             ->toPNG();
 
-        $this->assertTrue($img->isResource());
+        $this->assertTrue($img->isImageString());
         $this->assertNotNull($img->save(GIMAGE_PATH_TMP . DS . 'rectangle.png'));
     }
 }


### PR DESCRIPTION
1. `$url` is undefined in `loadImageFromResource` method.
2. `Utils::isJPGResource` and `Utils::isPNGResource` method require a string parameter. GD library can't obtain image type through resource.