### PR TITLE
Load an image from a `resource` or `\GdImage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ docker-format:
 	@echo "Formatting Gimage with PHP 8.0"
 	@docker run --rm -it -v $(PWD):/var/www/html joseluisq/php-fpm:8.0 \
 		sh -c 'php -v && composer run-script format'
+.PHONY: docker-format
 
 docs:
 	@mkdocs serve -e docs -a 0.0.0.0:8000

--- a/examples/rectangle.php
+++ b/examples/rectangle.php
@@ -27,4 +27,4 @@ $figure
     ->setBackgroundColor(0, 0, 255)
     ->setOpacity(0.5)
     ->create()
-    ->save(__DIR__ . '/reactangle.png');
+    ->save(__DIR__ . '/rectangle.png');

--- a/examples/resource.php
+++ b/examples/resource.php
@@ -32,7 +32,8 @@ imagefilledrectangle($rectangle, 0, 0, $width, $height, $green);
 $img = new Image();
 $img
     ->load($rectangle)
+    // we need to tell GImage about the image type
+    ->toPNG()
     // scale to 50%
     ->scale(0.50)
-    ->toPNG()
     ->save(__DIR__ . '/rectangle.png');


### PR DESCRIPTION
This PR adds support for loading an image from a `resource` (PHP 7.4) or a `\GdImage` (PHP 8.0+). It introduces `isImageResource()` and `isImageGdImage()` functions to get the image loaded method.